### PR TITLE
Switch to dark mode css variants

### DIFF
--- a/apps/rcd_web/assets/css/app.css
+++ b/apps/rcd_web/assets/css/app.css
@@ -1,143 +1,146 @@
 /*! purgecss start ignore */
+
 @tailwind base;
 
 @tailwind components;
 
-/* Dark Theme (default) */
-:root {
-  --color-red: #EF5350;
-  --color-green: #22DA6E;
-  --color-orange: #F78C6C;
-  --color-blue: #82AAFF;
-  --color-magenta: #C792EA;
-  --color-cyan: #21C7A8;
-  --color-yellow: #ADDB67;
-  --color-white: #ffffff;
-
-  --color-gray-100: #D6DEEB;
-  --color-gray-200: #A4AEBE;
-  --color-gray-400: #5F7777;
-  --color-gray-500: #4C5862;
-
-  /* --color-background-200: #5f7D97; */
-  --color-background-500: #13344f;
-  --color-background-700: #092034;
-  --color-background-900: #011627;
-
-  --font-display: "dm", monospace;
-  --font-body: "dm", monospace;
-
-  --font-weight-normal: 400;
-  --font-weight-display: 400;
-  --font-weight-btn: 600;
-}
-
-/* Light Theme */
-.theme-light {
-  --color-red: #EF5350;
-  --color-green: #22DA6E;
-  --color-orange: #F78C6C;
-  --color-blue: #82AAFF;
-  --color-magenta: #C792EA;
-  --color-cyan: #21C7A8;
-  --color-yellow: #ADDB67;
-  --color-white: #ffffff;
-
-  --color-gray-100: #D6DEEB;
-  --color-gray-200: #5F7777;
-  --color-gray-400: #5F7777;
-  --color-gray-500: #4C5862;
-
-  --color-background-500: #D3E8F8;
-  --color-background-700: #D3E8F8;
-  --color-background-900: #F0F0F0;
-
-  --font-display: "dm", monospace;
-  --font-body: "dm", monospace;
-
-  --font-weight-normal: 400;
-  --font-weight-display: 400;
-  --font-weight-btn: 600;
-}
 /*! purgecss end ignore */
 
-@tailwind utilities;
-
-/* Labels */
+/* labels */
 label {
-  @apply block text-sm font-medium leading-5 text-default;
+  @apply block text-sm font-medium leading-5;
 }
 
-/* Inputs */
+/* regular text inputs light mode*/
 input:not([type=submit]):not([type=file]):not([type=checkbox]):not([type=radio]) {
-  @apply appearance-none block w-full bg-900 px-3 py-2 text-primary border border-gray-500 rounded-md transition duration-150 ease-in-out;
+  @apply appearance-none block w-full bg-transparent text-owl-900 px-3 py-2 border border-owl-600 rounded-md transition duration-150 ease-in-out;
 }
 
+/* regular text inputs dark mode*/
+.mode-dark input:not([type=submit]):not([type=file]):not([type=checkbox]):not([type=radio]) {
+  @apply text-owl-400;
+}
+
+/* Regular text inputs :focus dark mode */
 input:not([type=submit]):not([type=file]):not([type=checkbox]):not([type=radio]):focus {
+  @apply outline-none border-dark-blue;
+}
+
+/* Regular text inputs :focus light mode */
+.mode-dark input:not([type=submit]):not([type=file]):not([type=checkbox]):not([type=radio]):focus {
   @apply outline-none border-blue;
 }
 
+/* Regular text inputs :placeholder light mode */
 input:not([type=submit]):not([type=file]):not([type=checkbox]):not([type=radio]):placeholder {
-  @apply text-gray-500;
+  @apply text-owl-900;
 }
 
+/* Regular text inputs :placeholder dark mode */
+.mode-dark input:not([type=submit]):not([type=file]):not([type=checkbox]):not([type=radio]):placeholder {
+  @apply text-owl-600;
+}
+
+/* checkboxes */
+input[type=checkbox] {
+  @apply h-4 w-4 bg-transparent text-owl-200 border-owl-600 transition duration-150 ease-in-out;
+}
+
+/* checkboxes dark mode */
+.mode-dark input[type=checkbox] {
+  @apply text-owl-600;
+}
+
+/* checkboxes :focus light mode */
+input[type=checkbox]:focus {
+  @apply outline-none border-dark-blue shadow-none;
+}
+
+/* checkboxes :focus dark mode */
+input[type=checkbox]:focus {
+  @apply outline-none border-blue shadow-none;
+}
+
+/* basic button */
+.btn {
+  @apply flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md transition duration-150 ease-in-out;
+}
+
+/* basic button :hover light mode*/
+.btn:hover {
+  @apply text-owl-600;
+}
+
+/* basic button :hover dark mode*/
+.mode-dark .btn:hover {
+  @apply text-owl-900;
+}
+
+/* basic button :focus light mode*/
+.btn:focus {
+  @apply outline-none border-dark-blue;
+}
+
+/* basic button :focus dark mode */
+.mode-dark .btn:focus {
+  @apply outline-none border-blue;
+}
+
+/* primary button light mode */
+.btn-primary {
+  @apply bg-owl-300;
+}
+
+/* primary button dark mode*/
+.mode-dark .btn-primary {
+  @apply bg-owl-700;
+}
+
+/* primary button :hover */
+.btn-primary:hover {
+  @apply bg-blue;
+}
+
+/* secondary button light mode */
+.btn-secondary {
+  @apply bg-owl-200;
+}
+
+/* secondary button dark mode */
+.mode-dark .btn-secondary {
+  @apply bg-owl-800;
+}
+
+/* secondary button :hover */
+.btn-secondary:hover {
+  @apply bg-cyan;
+}
+
+/* headings */
+h1 {
+  @apply text-4xl leading-9;
+}
+
+h2 {
+  @apply text-3xl leading-9;
+}
+
+h3 {
+  @apply text-2xl leading-9;
+}
+
+/* unordered lists */
+ul {
+  @apply list-inside list-disc;
+}
+
+
+/* small screen breakpoint */
 @screen sm {
+  /* regular text inputs */
   input:not([type=submit]):not([type=file]):not([type=checkbox]):not([type=radio]) {
     @apply text-sm leading-5;
   }
 }
 
-/* Checkboxes */
-input[type=checkbox] {
-  @apply h-4 w-4 bg-900 border-gray-500 text-gray-400 transition duration-150 ease-in-out;
-}
-
-input[type=checkbox]:focus {
-  @apply outline-none border-blue;
-}
-
-/* Buttons */
-.btn {
-  @apply flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-primary transition duration-150 ease-in-out;
-}
-
-.btn:hover {
-  @apply text-gray-500
-}
-
-.btn:focus {
-  @apply outline-none border-indigo-700 shadow-outline-indigo;
-}
-
-.btn-primary {
-  @apply bg-500;
-}
-
-.btn-primary:hover {
-  @apply bg-blue;
-}
-
-.btn-secondary {
-  @apply bg-700
-}
-
-.btn-secondary:hover {
-  @apply bg-cyan;
-}
-
-/* Headings */
-h1 {
-  @apply text-4xl leading-9 text-primary;
-}
-
-h2 {
-  @apply text-3xl leading-9 text-primary;
-}
-
-h3 {
-  @apply text-2xl leading-9 text-default;
-}
-
-ul {
-  @apply text-default list-inside list-disc;
-}
+@tailwind utilities;

--- a/apps/rcd_web/assets/js/theme.js
+++ b/apps/rcd_web/assets/js/theme.js
@@ -12,7 +12,8 @@ window.theme = {
       ? 'light'
       : 'dark'
     // Enable theme transitions after the initial theme mode has been set.
-    document.documentElement.classList.add('transition', 'ease-in-out', 'duration-500')
+    document.body.classList.add('transition', 'ease-in-out', 'duration-500')
+
     // update local storage
     this.save()
     // update the theme class on the document root
@@ -24,10 +25,10 @@ window.theme = {
     window.localStorage.setItem('theme', this.mode)
   },
   updateDocument () {
-    document.documentElement.classList.remove('theme-light')
+    document.documentElement.classList.remove('mode-dark')
 
-    if (this.mode === 'light') {
-      document.documentElement.classList.add('theme-light')
+    if (this.mode === 'dark') {
+      document.documentElement.classList.add('mode-dark')
     }
   }
 }

--- a/apps/rcd_web/assets/package-lock.json
+++ b/apps/rcd_web/assets/package-lock.json
@@ -9672,6 +9672,15 @@
         }
       }
     },
+    "tailwindcss-dark-mode": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/tailwindcss-dark-mode/-/tailwindcss-dark-mode-1.1.4.tgz",
+      "integrity": "sha512-e0zgg6V5wc+pUHLdjc7oxnbetcPv0hqvUPMfK3tvugwyEZtG8n8FhDu3kkPbu7KwAqB7NQ8aONITv+jB2TVpRA==",
+      "dev": true,
+      "requires": {
+        "tailwindcss": "^1.2.0"
+      }
+    },
     "tapable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",

--- a/apps/rcd_web/assets/package.json
+++ b/apps/rcd_web/assets/package.json
@@ -25,6 +25,7 @@
     "postcss-loader": "^3.0.0",
     "standard": "^14.3.3",
     "tailwindcss": "^1.4.0",
+    "tailwindcss-dark-mode": "^1.1.4",
     "uglifyjs-webpack-plugin": "^1.2.4",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3"

--- a/apps/rcd_web/assets/tailwind.config.js
+++ b/apps/rcd_web/assets/tailwind.config.js
@@ -1,43 +1,56 @@
 module.exports = {
-  purge: [
-    '../lib/rcd_web/live/**/*.ex',
-    '../lib/rcd_web/templates/**/*.eex',
-    '../lib/rcd_web/templates/**/*.leex',
-    '../lib/rcd_web/views/**/*.ex',
-    './js/**/*.js'
-  ],
+  purge: {
+    content: [
+      '../lib/rcd_web/live/**/*.ex',
+      '../lib/rcd_web/templates/**/*.eex',
+      '../lib/rcd_web/templates/**/*.leex',
+      '../lib/rcd_web/views/**/*.ex',
+      './js/**/*.js'
+    ],
+    options: {
+      whitelist: ['mode-dark']
+    }
+  },
   theme: {
+    fontFamily: {
+      dm: ['dm', 'monospace']
+    },
+    customForms: theme => ({
+      default: {
+        checkbox: {
+          iconColor: theme('colors.owl-400')
+        }
+      }
+    }),
     extend: {
       colors: {
-        'gray-100': 'var(--color-gray-100)',
-        'gray-400': 'var(--color-gray-400)',
-        'gray-500': 'var(--color-gray-500)',
-        blue: 'var(--color-blue)',
-        cyan: 'var(--color-cyan)',
-        red: 'var(--color-red)'
-      },
-      textColor: {
-        primary: 'var(--color-gray-200)',
-        default: 'var(--color-gray-400)'
-      },
-      backgroundColor: {
-        500: 'var(--color-background-500)',
-        700: 'var(--color-background-700)',
-        900: 'var(--color-background-900)'
-      },
-      fontFamily: {
-        display: 'var(--font-display)',
-        body: 'var(--font-body)'
-      },
-      fontWeights: {
-        normal: 'var(--font-weight-normal)',
-        display: 'var(--font-weight-display)',
-        btn: 'var(--font-weight-btn)'
+        red: '#EF5350',
+        'dark-red': '#DE3D3B',
+        green: '#22DA6E',
+        'dark-green': '#08916A',
+        blue: '#82AAFF',
+        'dark-blue': '#288ED7',
+        cyan: '#2AA298',
+        'light-cyan': '#21C7A8',
+        'owl-100': '#F0F0F0',
+        'owl-200': '#D6DEEB',
+        'owl-300': '#D3E8F8',
+        'owl-400': '#A4AEBE',
+        'owl-500': '#5F7777',
+        'owl-600': '#4C5862',
+        'owl-700': '#13344f',
+        'owl-800': '#092034',
+        'owl-900': '#011627'
       }
     }
   },
-  variants: {},
+  variants: {
+    backgroundColor: ['dark', 'dark-hover', 'dark-group-hover', 'dark-even', 'dark-odd', 'hover'],
+    borderColor: ['dark', 'dark-focus', 'dark-focus-within'],
+    textColor: ['dark', 'dark-hover', 'dark-active', 'dark-placeholder', 'hover']
+  },
   plugins: [
-    require('@tailwindcss/ui')
+    require('@tailwindcss/ui'),
+    require('tailwindcss-dark-mode')()
   ]
 }

--- a/apps/rcd_web/lib/rcd_web/templates/layout/_flash_messages.html.eex
+++ b/apps/rcd_web/lib/rcd_web/templates/layout/_flash_messages.html.eex
@@ -2,7 +2,7 @@
   <div class="rounded-md border border-cyan p-4">
     <div class="flex">
       <div class="flex-shrink-0">
-        <svg class="h-5 w-5 text-cyan" fill="currentColor" viewBox="0 0 20 20">
+        <svg class="h-5 w-5 dark:text-cyan text-dark-cyan" fill="currentColor" viewBox="0 0 20 20">
           <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
         </svg>
       </div>
@@ -18,12 +18,12 @@
   <div class="rounded-md border border-red p-4">
     <div class="flex">
       <div class="flex-shrink-0">
-        <svg class="h-5 w-5 text-red" fill="currentColor" viewBox="0 0 20 20">
+        <svg class="h-5 w-5 dark:text-red text-dark-red" fill="currentColor" viewBox="0 0 20 20">
           <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
         </svg>
       </div>
       <div class="ml-3">
-        <div class="text-sm leading-5 text-red">
+        <div class="text-sm leading-5 dark:text-red text-dark-red">
           <p><%= get_flash(@conn, :error) %></p>
         </div>
       </div>

--- a/apps/rcd_web/lib/rcd_web/templates/layout/_portal_nav.html.eex
+++ b/apps/rcd_web/lib/rcd_web/templates/layout/_portal_nav.html.eex
@@ -1,10 +1,10 @@
-<nav class="border-b border-gray-500" role="navigation" x-data="{ mobileMenuVisible: false, profileMenuVisible: false }">
+<nav class="border-b dark:border-owl-600 border-owl-900" role="navigation" x-data="{ mobileMenuVisible: false, profileMenuVisible: false }">
   <div class="max-w-7xl mx-auto px-2 sm:px-6 lg:px-8">
     <div class="relative flex items-center justify-between h-16">
       <div class="absolute inset-y-0 left-0 flex items-center sm:hidden">
         <!-- Mobile menu button-->
         <button
-          class="inline-flex items-center justify-center p-2 rounded-md text-default hover:text-primary hover:bg-500 focus:outline-none focus:bg-500 focus:text-primary transition duration-150 ease-in-out"
+          class="inline-flex items-center justify-center p-2 rounded-md transition duration-150 ease-in-out"
           @click="mobileMenuVisible = !mobileMenuVisible"
         >
           <!-- Icon when menu is closed. -->
@@ -21,7 +21,7 @@
       </div>
       <div class="flex-1 flex items-center justify-center sm:items-stretch sm:justify-start">
         <div class="flex-shrink-0 -center">
-          <%= render RcdWeb.IconsView, "_moose.html", class: "w-8 fill-current text-default" %>
+          <%= render RcdWeb.IconsView, "_moose.html", class: "w-8 fill-current dark:text-owl-400 text-owl-900" %>
         </div>
         <%# Desktop Nav Links %>
         <div class="hidden sm:block sm:ml-6">
@@ -33,14 +33,14 @@
       </div>
       <div class="absolute inset-y-0 right-0 flex items-center pr-2 sm:static sm:inset-auto sm:ml-6 sm:pr-0">
         <%# Notifications %>
-        <%# <button class="p-1 border-2 border-transparent text-gray-400 rounded-full hover:text-white focus:outline-none focus:text-white focus:bg-gray-700 transition duration-150 ease-in-out">
+        <%# <button class="p-1 border-2 border-transparent text-owl-400 rounded-full hover:text-white focus:outline-none focus:text-white focus:bg-gray-700 transition duration-150 ease-in-out">
           <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
           </svg>
         </button> %>
 
         <%# Theme Toggle %>
-        <div class="flex font-display text-default p-2 z-10 justify-between">
+        <div class="flex font-display text-owl-900 dark:text-owl-400 p-2 z-10 justify-between">
           <%= render "_theme_toggle.html", assigns %>
         </div>
 
@@ -65,9 +65,9 @@
             x-transition:leave-end="transform opacity-0 scale-95"
             @click.away="profileMenuVisible = false"
           >
-            <div class="py-1 rounded-md bg-900 shadow-xs border border-gray-500">
-              <%= link "Settings", to: Routes.user_settings_path(@conn, :edit), class: "block px-4 py-2 text-sm leading-5 text-default hover:text-primary hover:bg-500 focus:outline-none focus:bg-500 transition duration-150 ease-in-out" %>
-              <%= link "Logout", to: Routes.user_session_path(@conn, :delete), method: :delete, class: "block px-4 py-2 text-sm leading-5 text-default hover:text-primary hover:bg-500 focus:outline-none focus:bg-500 transition duration-150 ease-in-out" %>
+            <div class="py-1 rounded-md bg-owl-100 dark:bg-owl-900 shadow-xs border border-owl-600">
+              <%= link "Settings", to: Routes.user_settings_path(@conn, :edit), class: "block px-4 py-2 text-sm leading-5 text-owl-900 dark:text-owl-400 dark-hover:text-owl-200  hover:bg-owl-200 dark-hover:bg-owl-800 transition duration-150 ease-in-out" %>
+              <%= link "Logout", to: Routes.user_session_path(@conn, :delete), method: :delete, class: "block px-4 py-2 text-sm leading-5 text-owl-900 dark:text-owl-400 dark-hover:text-owl-200  hover:bg-owl-200 dark-hover:bg-owl-800 transition duration-150 ease-in-out" %>
             </div>
           </div>
         </div>

--- a/apps/rcd_web/lib/rcd_web/templates/layout/app.html.eex
+++ b/apps/rcd_web/lib/rcd_web/templates/layout/app.html.eex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="bg-900 font-display h-screen">
+<html lang="en" class="h-screen font-dm">
   <head>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
@@ -7,11 +7,11 @@
     <title>ryandurham.com</title>
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
   </head>
-  <body class="h-screen">
+  <body class="h-screen bg-owl-100 dark:bg-owl-900 text-owl-900 dark:text-owl-400">
     <main role="main" class="h-screen">
       <%= @inner_content %>
     </main>
-    <footer class="absolute right-0 bottom-0 left-0 flex font-display text-default p-2 z-10 justify-between">
+    <footer class="absolute right-0 bottom-0 left-0 flex text-owl-900 dark:text-owl-400 p-2 z-10 justify-between">
       <%= render "_theme_toggle.html", assigns %>
       <p class="text-xs">
         <a href="https://github.com/sdras/night-owl-vscode-theme" target="_blank">night owl</a> /

--- a/apps/rcd_web/lib/rcd_web/templates/layout/portal.html.eex
+++ b/apps/rcd_web/lib/rcd_web/templates/layout/portal.html.eex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="bg-900 font-display h-screen">
+<html lang="en" class="h-screen font-dm">
   <head>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
@@ -7,7 +7,7 @@
     <title>ryandurham.com</title>
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
   </head>
-  <body>
+  <body class="bg-owl-100 dark:bg-owl-900 text-owl-900 dark:text-owl-400">
     <header>
       <nav role="navigation">
         <%= render "_portal_nav.html", assigns %>

--- a/apps/rcd_web/lib/rcd_web/templates/page/index.html.eex
+++ b/apps/rcd_web/lib/rcd_web/templates/page/index.html.eex
@@ -1,3 +1,3 @@
-<section class="absolute text-default text-2xl inset-0 flex items-center justify-center z-0">
+<section class="absolute text-owl-400 text-2xl inset-0 flex items-center justify-center z-0">
   <p>ryandurham.com</p>
 </section>

--- a/apps/rcd_web/lib/rcd_web/templates/user_registration/new.html.eex
+++ b/apps/rcd_web/lib/rcd_web/templates/user_registration/new.html.eex
@@ -1,23 +1,23 @@
 <div class="min-h-screen flex flex-col justify-center py-12 sm:px-6 lg:px-8">
   <div class="sm:mx-auto sm:w-full sm:max-w-md">
-    <%= render RcdWeb.IconsView, "_moose.html", class: "w-auto h-12 mx-auto fill-current text-primary" %>
+    <%= render RcdWeb.IconsView, "_moose.html", class: "w-auto h-12 mx-auto fill-current dark:text-owl-200 text-owl-900" %>
     <h2 class="mt-6 text-center">
       Create a New Account
     </h2>
   </div>
 
   <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-    <div class="py-8 px-4 sm:rounded sm:px-10 border border-gray-500">
+    <div class="py-8 px-4 sm:rounded sm:px-10 border dark:border-owl-600 border-owl-900">
       <%= if @changeset.action do %>
         <div class="rounded-md border border-red p-4 mb-4">
           <div class="flex">
             <div class="flex-shrink-0">
-              <svg class="h-5 w-5 text-red" fill="currentColor" viewBox="0 0 20 20">
+              <svg class="h-5 w-5 dark:text-red text-dark-red" fill="currentColor" viewBox="0 0 20 20">
                 <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
               </svg>
             </div>
             <div class="ml-3">
-              <div class="text-sm leading-5 text-red">
+              <div class="text-sm leading-5 dark:text-red text-dark-red">
                 <p>Oops, something went wrong! Please check the errors below.</p>
               </div>
             </div>
@@ -51,13 +51,13 @@
           </div>
 
           <div class="text-sm leading-5">
-            <%= link "Forgot your password?", to: Routes.user_reset_password_path(@conn, :new), class: "font-medium text-default hover:text-blue focus:outline-none focus:underline transition ease-in-out duration-150" %>
+            <%= link "Forgot your password?", to: Routes.user_reset_password_path(@conn, :new), class: "font-medium text-owl-400 hover:text-blue focus:outline-none focus:underline transition ease-in-out duration-150" %>
           </div>
         </div>
 
         <div class="mt-6">
           <span class="block w-full rounded-md shadow-sm">
-            <%= submit "Register", class: "w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-primary hover:text-gray-500 bg-500 hover:bg-blue focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition duration-150 ease-in-out" %>
+            <%= submit "Register", class: "w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-owl-200 hover:text-owl-600 bg-500 hover:bg-blue focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition duration-150 ease-in-out" %>
           </span>
         </div>
       <% end %>

--- a/apps/rcd_web/lib/rcd_web/templates/user_reset_password/edit.html.eex
+++ b/apps/rcd_web/lib/rcd_web/templates/user_reset_password/edit.html.eex
@@ -1,13 +1,13 @@
 <div class="min-h-screen flex flex-col justify-center py-12 sm:px-6 lg:px-8">
   <div class="sm:mx-auto sm:w-full sm:max-w-md">
-    <%= render RcdWeb.IconsView, "_moose.html", class: "w-auto h-12 mx-auto fill-current text-primary" %>
+    <%= render RcdWeb.IconsView, "_moose.html", class: "w-auto h-12 mx-auto fill-current dark:text-owl-200 text-owl-900" %>
     <h2 class="mt-6 text-center">
       Reset Your Password
     </h2>
   </div>
 
   <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-    <div class="py-8 px-4 sm:rounded sm:px-10 border border-gray-500">
+    <div class="py-8 px-4 sm:rounded sm:px-10 border dark:border-owl-600 border-owl-900">
       <%= form_for @changeset, Routes.user_reset_password_path(@conn, :update, @token), fn f -> %>
         <%= if @changeset.action do %>
           <div class="alert alert-danger">
@@ -33,7 +33,7 @@
 
         <div class="mt-6">
           <span class="block w-full rounded-md shadow-sm">
-            <%= submit "Reset Password", class: "w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-primary hover:text-gray-500 bg-500 hover:bg-blue focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition duration-150 ease-in-out" %>
+            <%= submit "Reset Password", class: "w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-owl-200 hover:text-owl-600 bg-500 hover:bg-blue focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition duration-150 ease-in-out" %>
           </span>
         </div>
       <% end %>
@@ -41,17 +41,17 @@
       <div class="mt-6">
         <div class="relative">
           <div class="absolute inset-0 flex items-center">
-            <div class="w-full border-t border-gray-500"></div>
+            <div class="w-full border-t border-owl-600"></div>
           </div>
           <div class="relative flex justify-center text-sm leading-5">
-            <span class="px-2 bg-900 text-default transition ease-in-out duration-500">
+            <span class="px-2 bg-900 text-owl-400 transition ease-in-out duration-500">
               or
             </span>
           </div>
         </div>
 
         <div class="mt-6 flex ">
-          <%= link "Login", to: Routes.user_session_path(@conn, :new), class: "w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-primary hover:text-gray-500 bg-700 hover:bg-cyan focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition duration-150 ease-in-out" %>
+          <%= link "Login", to: Routes.user_session_path(@conn, :new), class: "w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-owl-200 hover:text-owl-600 bg-700 hover:bg-cyan focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition duration-150 ease-in-out" %>
         </div>
       </div>
     </div>

--- a/apps/rcd_web/lib/rcd_web/templates/user_reset_password/new.html.eex
+++ b/apps/rcd_web/lib/rcd_web/templates/user_reset_password/new.html.eex
@@ -1,18 +1,18 @@
 <div class="min-h-screen flex flex-col justify-center py-12 sm:px-6 lg:px-8">
   <div class="sm:mx-auto sm:w-full sm:max-w-md">
-    <%= render RcdWeb.IconsView, "_moose.html", class: "w-auto h-12 mx-auto fill-current text-primary" %>
+    <%= render RcdWeb.IconsView, "_moose.html", class: "w-auto h-12 mx-auto fill-current dark:text-owl-200 text-owl-900" %>
     <h2 class="mt-6 text-center">
       Forgot Your Password?
     </h2>
   </div>
 
   <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-    <div class="py-8 px-4 sm:rounded sm:px-10 border border-gray-500">
+    <div class="py-8 px-4 sm:rounded sm:px-10 border dark:border-owl-600 border-owl-900">
       <%= form_for :user, Routes.user_reset_password_path(@conn, :create), fn f -> %>
         <div>
           <%= label f, :email %>
           <div class="mt-1 rounded-md shadow-sm">
-            <%= text_input f, :email, required: true, placeholder: 'type something', class: "appearance-none block w-full bg-900 px-3 py-2 text-gray-100 border border-gray-500 rounded-md placeholder-gray-400 focus:outline-none focus:border-blue transition duration-150 ease-in-out sm:text-sm sm:leading-5" %>
+            <%= text_input f, :email, required: true %>
           </div>
         </div>
 
@@ -26,10 +26,10 @@
       <div class="mt-6">
         <div class="relative">
           <div class="absolute inset-0 flex items-center">
-            <div class="w-full border-t border-gray-500"></div>
+            <div class="w-full border-t border-owl-600"></div>
           </div>
           <div class="relative flex justify-center text-sm leading-5">
-            <span class="px-2 bg-900 text-default transition ease-in-out duration-500">
+            <span class="px-2 bg-owl-100 dark:bg-owl-900 transition ease-in-out duration-500">
               or
             </span>
           </div>

--- a/apps/rcd_web/lib/rcd_web/templates/user_session/new.html.eex
+++ b/apps/rcd_web/lib/rcd_web/templates/user_session/new.html.eex
@@ -1,6 +1,6 @@
 <div class="min-h-screen flex flex-col justify-center py-12 sm:px-6 lg:px-8">
   <div class="sm:mx-auto sm:w-full sm:max-w-md mb-4">
-    <%= render RcdWeb.IconsView, "_moose.html", class: "w-auto h-12 mx-auto fill-current text-primary" %>
+    <%= render RcdWeb.IconsView, "_moose.html", class: "w-auto h-12 mx-auto fill-current dark:text-owl-200 text-owl-900" %>
     <h2 class="mt-6 text-center">
       Login
     </h2>
@@ -11,17 +11,17 @@
   </div>
 
   <div class="mt-4 sm:mx-auto sm:w-full sm:max-w-md">
-    <div class="py-8 px-4 sm:rounded sm:px-10 border border-gray-500">
+    <div class="py-8 px-4 sm:rounded sm:px-10 border dark:border-owl-600 border-owl-900">
       <%= if @error_message do %>
         <div class="rounded-md border border-red p-4 mb-4">
           <div class="flex">
             <div class="flex-shrink-0">
-              <svg class="h-5 w-5 text-red" fill="currentColor" viewBox="0 0 20 20">
+              <svg class="h-5 w-5 dark:text-red text-dark-red" fill="currentColor" viewBox="0 0 20 20">
                 <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
               </svg>
             </div>
             <div class="ml-3">
-              <div class="text-sm leading-5 text-red">
+              <div class="text-sm leading-5 dark:text-red text-dark-red">
                 <p><%= @error_message %></p>
               </div>
             </div>
@@ -53,7 +53,7 @@
           </div>
 
           <div class="text-sm leading-5">
-            <%= link "Forgot your password?", to: Routes.user_reset_password_path(@conn, :new), class: "font-medium text-default hover:text-blue focus:outline-none focus:underline transition ease-in-out duration-150" %>
+            <%= link "Forgot your password?", to: Routes.user_reset_password_path(@conn, :new), class: "font-medium text-owl-400 hover:text-blue focus:outline-none focus:underline transition ease-in-out duration-150" %>
           </div>
         </div>
 

--- a/apps/rcd_web/lib/rcd_web/templates/user_settings/edit.html.eex
+++ b/apps/rcd_web/lib/rcd_web/templates/user_settings/edit.html.eex
@@ -7,12 +7,12 @@
     <div class="rounded-md border border-red p-4 my-4">
       <div class="flex">
         <div class="flex-shrink-0">
-          <svg class="h-5 w-5 text-red" fill="currentColor" viewBox="0 0 20 20">
+          <svg class="h-5 w-5 dark:text-red text-dark-red" fill="currentColor" viewBox="0 0 20 20">
             <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
           </svg>
         </div>
         <div class="ml-3">
-          <div class="text-sm leading-5 text-red">
+          <div class="text-sm leading-5 dark:text-red text-dark-red">
             <p>Oops, something went wrong! Please check the errors below.</p>
           </div>
         </div>
@@ -48,12 +48,12 @@
     <div class="rounded-md border border-red p-4 my-4">
       <div class="flex">
         <div class="flex-shrink-0">
-          <svg class="h-5 w-5 text-red" fill="currentColor" viewBox="0 0 20 20">
+          <svg class="h-5 w-5 dark:text-red text-dark-red" fill="currentColor" viewBox="0 0 20 20">
             <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
           </svg>
         </div>
         <div class="ml-3">
-          <div class="text-sm leading-5 text-red">
+          <div class="text-sm leading-5 dark:text-red text-dark-red">
             <p>Oops, something went wrong! Please check the errors below.</p>
           </div>
         </div>

--- a/apps/rcd_web/lib/rcd_web/views/error_helpers.ex
+++ b/apps/rcd_web/lib/rcd_web/views/error_helpers.ex
@@ -10,7 +10,7 @@ defmodule RcdWeb.ErrorHelpers do
   """
   def error_tag(form, field) do
     Enum.map(Keyword.get_values(form.errors, field), fn error ->
-      content_tag(:span, translate_error(error), class: "text-red")
+      content_tag(:span, translate_error(error), class: "dark:text-red text-dark-red")
     end)
   end
 

--- a/apps/rcd_web/lib/rcd_web/views/layout_view.ex
+++ b/apps/rcd_web/lib/rcd_web/views/layout_view.ex
@@ -10,20 +10,21 @@ defmodule RcdWeb.LayoutView do
 
   def desktop_nav_button_classes(conn, action, extra \\ "") do
     if action_name(conn) == action do
-      "px-3 py-2 rounded-md font-medium leading-5 text-primary bg-700 focus:outline-none focus:text-primary focus:bg-500 transition duration-150 ease-in-out " <>
+      "px-3 py-2 rounded-md font-medium leading-5 text-owl-900 dark:text-owl-200 bg-owl-300 dark:bg-owl-700 transition duration-150 ease-in-out " <>
         extra
     else
-      "px-3 py-2 rounded-md font-medium leading-5 text-default hover:text-primary hover:bg-500 focus:outline-none focus:text-primary focus:bg-500 transition duration-150 ease-in-out " <>
+      "px-3 py-2 rounded-md font-medium leading-5 text-owl-900 dark:text-owl-400 dark-hover:text-owl-200  hover:bg-owl-200 dark-hover:bg-owl-800 transition duration-150 ease-in-out " <>
         extra
     end
+    #
   end
 
   def mobile_nav_button_classes(conn, action, extra \\ "") do
     if action_name(conn) == action do
-      "block px-3 py-2 rounded-md text-base font-medium text-primary bg-700 focus:outline-none transition duration-150 ease-in-out " <>
+      "block px-3 py-2 rounded-md text-base font-medium text-owl-900 dark:text-owl-200 bg-owl-300 dark:bg-owl-700 transition duration-150 ease-in-out " <>
         extra
     else
-      "block px-3 py-2 rounded-md text-base font-medium text-default hover:text-primary hover:bg-500 focus:outline-none focus:text-primary focus:bg-500 transition duration-150 ease-in-out " <>
+      "block px-3 py-2 rounded-md text-base font-medium text-owl-900 dark:text-owl-400 dark-hover:text-owl-200  hover:bg-owl-200 dark-hover:bg-owl-800 transition duration-150 ease-in-out " <>
         extra
     end
   end

--- a/config/prod.secret.example
+++ b/config/prod.secret.example
@@ -11,6 +11,13 @@ config :library, Library.Repo,
   hostname: "localhost",
   pool_size: 10
 
+config :admin, Admin.Repo,
+  username: "ryan",
+  password: "secret",
+  database: "ryandurham.com",
+  hostname: "localhost",
+  pool_size: 10
+
 secret_key_base =
   System.get_env("SECRET_KEY_BASE") ||
     raise """


### PR DESCRIPTION
This PR adds a plugin for generating dark mode variants in Tailwind, and re-implements the design
using these variants instead of css variables. 
