### PR TITLE
auth updates 2020 05 10

### DIFF
--- a/apps/admin/lib/admin/accounts.ex
+++ b/apps/admin/lib/admin/accounts.ex
@@ -137,7 +137,7 @@ defmodule Admin.Accounts do
   def update_user_email(user, token) do
     context = "change:#{user.email}"
 
-    with {:ok, query} <- UserToken.verify_user_change_email_token_query(token, context),
+    with {:ok, query} <- UserToken.verify_change_email_token_query(token, context),
          %UserToken{sent_to: email} <- Repo.one(query),
          {:ok, _} <- Repo.transaction(user_email_multi(user, email, context)) do
       :ok
@@ -165,8 +165,7 @@ defmodule Admin.Accounts do
   """
   def deliver_update_email_instructions(%User{} = user, current_email, update_email_url_fun)
       when is_function(update_email_url_fun, 1) do
-    {encoded_token, user_token} =
-      UserToken.build_user_email_token(user, "change:#{current_email}")
+    {encoded_token, user_token} = UserToken.build_email_token(user, "change:#{current_email}")
 
     Repo.insert!(user_token)
     UserNotifier.deliver_update_email_instructions(user, update_email_url_fun.(encoded_token))
@@ -259,7 +258,7 @@ defmodule Admin.Accounts do
     if user.confirmed_at do
       {:error, :already_confirmed}
     else
-      {encoded_token, user_token} = UserToken.build_user_email_token(user, "confirm")
+      {encoded_token, user_token} = UserToken.build_email_token(user, "confirm")
       Repo.insert!(user_token)
       UserNotifier.deliver_confirmation_instructions(user, confirmation_url_fun.(encoded_token))
     end
@@ -272,7 +271,7 @@ defmodule Admin.Accounts do
   and the token is deleted.
   """
   def confirm_user(token) do
-    with {:ok, query} <- UserToken.verify_user_email_token_query(token, "confirm"),
+    with {:ok, query} <- UserToken.verify_email_token_query(token, "confirm"),
          %User{} = user <- Repo.one(query),
          {:ok, %{user: user}} <- Repo.transaction(confirm_user_multi(user)) do
       {:ok, user}
@@ -300,7 +299,7 @@ defmodule Admin.Accounts do
   """
   def deliver_user_reset_password_instructions(%User{} = user, reset_password_url_fun)
       when is_function(reset_password_url_fun, 1) do
-    {encoded_token, user_token} = UserToken.build_user_email_token(user, "reset_password")
+    {encoded_token, user_token} = UserToken.build_email_token(user, "reset_password")
     Repo.insert!(user_token)
     UserNotifier.deliver_reset_password_instructions(user, reset_password_url_fun.(encoded_token))
   end
@@ -318,7 +317,7 @@ defmodule Admin.Accounts do
 
   """
   def get_user_by_reset_password_token(token) do
-    with {:ok, query} <- UserToken.verify_user_email_token_query(token, "reset_password"),
+    with {:ok, query} <- UserToken.verify_email_token_query(token, "reset_password"),
          %User{} = user <- Repo.one(query) do
       user
     else

--- a/apps/admin/lib/admin/accounts/user.ex
+++ b/apps/admin/lib/admin/accounts/user.ex
@@ -43,17 +43,15 @@ defmodule Admin.Accounts.User do
     # |> validate_format(:password, ~r/[a-z]/, message: "at least one lower case character")
     # |> validate_format(:password, ~r/[A-Z]/, message: "at least one upper case character")
     # |> validate_format(:password, ~r/[!?@#$%^&*_0-9]/, message: "at least one digit or punctuation character")
-    |> prepare_changes(&maybe_hash_password/1)
+    |> prepare_changes(&hash_password/1)
   end
 
-  defp maybe_hash_password(changeset) do
-    if password = get_change(changeset, :password) do
-      changeset
-      |> put_change(:hashed_password, Bcrypt.hash_pwd_salt(password))
-      |> delete_change(:password)
-    else
-      changeset
-    end
+  defp hash_password(changeset) do
+    password = get_change(changeset, :password)
+
+    changeset
+    |> put_change(:hashed_password, Bcrypt.hash_pwd_salt(password))
+    |> delete_change(:password)
   end
 
   @doc """

--- a/apps/admin/lib/admin/accounts/user.ex
+++ b/apps/admin/lib/admin/accounts/user.ex
@@ -90,8 +90,6 @@ defmodule Admin.Accounts.User do
   @doc """
   Verifies the password.
 
-  Returns the given user if valid,
-
   If there is no user or the user doesn't have a password, we call
   `Bcrypt.no_user_verify/0` to avoid timing attacks.
   """

--- a/apps/admin/lib/admin/accounts/user_token.ex
+++ b/apps/admin/lib/admin/accounts/user_token.ex
@@ -101,7 +101,7 @@ defmodule Admin.Accounts.UserToken do
   @doc """
   Checks if the token is valid and returns its underlying lookup query.
 
-  The query returns the user found by the token.
+  The query returns the user token record.
   """
   def verify_change_email_token_query(token, context) do
     case Base.url_decode64(token, padding: false) do

--- a/apps/admin/lib/admin/accounts/user_token.ex
+++ b/apps/admin/lib/admin/accounts/user_token.ex
@@ -54,7 +54,7 @@ defmodule Admin.Accounts.UserToken do
   The token is valid for a week as long as users don't change
   their email.
   """
-  def build_user_email_token(user, context) do
+  def build_email_token(user, context) do
     build_hashed_token(user, context, user.email)
   end
 
@@ -76,7 +76,7 @@ defmodule Admin.Accounts.UserToken do
 
   The query returns the user found by the token.
   """
-  def verify_user_email_token_query(token, context) do
+  def verify_email_token_query(token, context) do
     case Base.url_decode64(token, padding: false) do
       {:ok, decoded_token} ->
         hashed_token = :crypto.hash(@hash_algorithm, decoded_token)
@@ -103,7 +103,7 @@ defmodule Admin.Accounts.UserToken do
 
   The query returns the user found by the token.
   """
-  def verify_user_change_email_token_query(token, context) do
+  def verify_change_email_token_query(token, context) do
     case Base.url_decode64(token, padding: false) do
       {:ok, decoded_token} ->
         hashed_token = :crypto.hash(@hash_algorithm, decoded_token)

--- a/apps/rcd_web/lib/rcd_web/controllers/user_auth.ex
+++ b/apps/rcd_web/lib/rcd_web/controllers/user_auth.ex
@@ -18,6 +18,11 @@ defmodule RcdWeb.UserAuth do
   It renews the session ID and clears the whole session
   to avoid fixation attacks. See the renew_session
   function to customize this behaviour.
+
+  It also sets a `:live_socket_id` key in the session,
+  so LiveView sessions are identified and automatically
+  disconnected on logout. The line can be safely removed
+  if you are not using LiveView.
   """
   def login_user(conn, user, params \\ %{}) do
     token = Accounts.generate_session_token(user)
@@ -26,6 +31,7 @@ defmodule RcdWeb.UserAuth do
     conn
     |> renew_session()
     |> put_session(:user_token, token)
+    |> put_session(:live_socket_id, "users_sessions:#{Base.url_encode64(token)}")
     |> maybe_write_remember_me_cookie(token, params)
     |> redirect(to: user_return_to || signed_in_path(conn))
   end
@@ -67,6 +73,10 @@ defmodule RcdWeb.UserAuth do
   def logout_user(conn) do
     user_token = get_session(conn, :user_token)
     user_token && Accounts.delete_session_token(user_token)
+
+    if live_socket_id = get_session(conn, :live_socket_id) do
+      RcdWeb.Endpoint.broadcast(live_socket_id, "disconnect", %{})
+    end
 
     conn
     |> renew_session()

--- a/apps/rcd_web/lib/rcd_web/router.ex
+++ b/apps/rcd_web/lib/rcd_web/router.ex
@@ -51,7 +51,6 @@ defmodule RcdWeb.Router do
   scope "/", RcdWeb do
     pipe_through [:browser, :require_authenticated_user, :portal_layout]
 
-    delete "/users/logout", UserSessionController, :delete
     get "/users/settings", UserSettingsController, :edit
     put "/users/settings/update_password", UserSettingsController, :update_password
     put "/users/settings/update_email", UserSettingsController, :update_email
@@ -78,6 +77,7 @@ defmodule RcdWeb.Router do
   scope "/", RcdWeb do
     pipe_through [:browser]
 
+    delete "/users/logout", UserSessionController, :delete
     get "/users/confirm", UserConfirmationController, :new
     post "/users/confirm", UserConfirmationController, :create
     get "/users/confirm/:token", UserConfirmationController, :confirm

--- a/apps/rcd_web/test/rcd_web/controllers/user_session_controller_test.exs
+++ b/apps/rcd_web/test/rcd_web/controllers/user_session_controller_test.exs
@@ -67,13 +67,15 @@ defmodule RcdWeb.UserSessionControllerTest do
   end
 
   describe "DELETE /users/logout" do
-    test "redirects if not logged in", %{conn: conn} do
-      conn = delete(conn, Routes.user_session_path(conn, :delete))
-      assert redirected_to(conn) == "/users/login"
-    end
-
     test "logs the user out", %{conn: conn, user: user} do
       conn = conn |> login_user(user) |> delete(Routes.user_session_path(conn, :delete))
+      assert redirected_to(conn) == @login_url
+      refute get_session(conn, :user_token)
+      assert get_flash(conn, :info) =~ "Logged out successfully"
+    end
+
+    test "succeeds even if the user is not logged in", %{conn: conn} do
+      conn = delete(conn, Routes.user_session_path(conn, :delete))
       assert redirected_to(conn) == @login_url
       refute get_session(conn, :user_token)
       assert get_flash(conn, :info) =~ "Logged out successfully"


### PR DESCRIPTION
This PR updates the generated auth scaffolding to be in line with phx_gen_auth /
mix_phx_gen_auth_demo
[83d5deb](https://github.com/dashbitco/mix_phx_gen_auth_demo/pull/1/commits/83d5deb33a9da42fd949d794f735773870882767)


- port: logout should succeed even if the user is already logged out
- port: update generated comments
- port: remove unecessary user_ prefix
- port: remove unused if
- port: set the live_socket_id on login and disconnect on logout
